### PR TITLE
load kernel modules on start

### DIFF
--- a/lib/nerves_system_rpi2.ex
+++ b/lib/nerves_system_rpi2.ex
@@ -1,0 +1,26 @@
+defmodule Nerves.System.Rpi2 do
+  use Application
+  @moduledoc false
+
+  @kernel_modules Mix.Project.config[:kernel_modules] || []
+
+  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # for more information on OTP Applications
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+    # Define workers and child supervisors to be supervised
+    children = [
+      worker(Task, [fn -> init_kernel_modules() end], restart: :transient, id: Nerves.Init.KernelModules),
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Nerves.System.Rpi2.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  def init_kernel_modules() do
+    Enum.each(@kernel_modules, & System.cmd("modprobe", [&1]))
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule NervesSystemRpi2.Mixfile do
+defmodule Nerves.System.Rpi2.Mixfile do
   use Mix.Project
 
   @version Path.join(__DIR__, "VERSION")
@@ -13,17 +13,18 @@ defmodule NervesSystemRpi2.Mixfile do
      description: description(),
      package: package(),
      deps: deps(),
+     kernel_modules: ["8192cu"],
      aliases: ["deps.precompile": ["nerves.env", "deps.precompile"]]]
   end
 
   def application do
-    []
+    [mod: {Nerves.System.Rpi2, []}]
   end
 
   defp deps do
-    [{:nerves, "~> 0.5", runtime: false },
-     {:nerves_system_br, "~> 0.10.0", runtime: false },
-     {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 0.10.0", runtime: false }]
+    [{:nerves, "~> 0.5", runtime: false},
+     {:nerves_system_br, "~> 0.10.0", runtime: false},
+     {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 0.10.0", runtime: false}]
   end
 
   defp description do


### PR DESCRIPTION
Who knows what modules to load? The system does :)

Requires `nerves_system_rpi2` to be allowed in the runtime.