### PR TITLE
nerves_system_br 0.13.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule NervesSystemRpi2.Mixfile do
   defp deps do
     [
       {:nerves, "~> 0.7", runtime: false },
-      {:nerves_system_br, "~> 0.13.3", runtime: false },
+      {:nerves_system_br, "~> 0.13.5", runtime: false },
       {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 0.11.0", runtime: false }
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"distillery": {:hex, :distillery, "1.4.1", "546d851bf27ae8fe0727e10e4fc4e146ad836eecee138263a60431e688044ed3", [:mix], [], "hexpm"},
   "nerves": {:hex, :nerves, "0.7.1", "2de3f2a7d05a6748d8fc1db6c64639b103185ebfa551a2516f9acfeb6177dae5", [:mix], [{:distillery, "~> 1.4", [hex: :distillery, repo: "hexpm", optional: false]}], "hexpm"},
-  "nerves_system_br": {:hex, :nerves_system_br, "0.13.3", "e5baa39be76646437a8e917e8bf1b3d41f6ef637c2806b500dade9aabdc9ae81", [:mix], [], "hexpm"},
+  "nerves_system_br": {:hex, :nerves_system_br, "0.13.5", "fb2bfa05c89e17d3cb2dac10f93bb64bb760991699502addf6c7d3af9910cc3b", [:mix], [], "hexpm"},
   "nerves_toolchain_arm_unknown_linux_gnueabihf": {:hex, :nerves_toolchain_arm_unknown_linux_gnueabihf, "0.11.0", "8d7606275a2d19de26ae238cd59475f4c06679aa9222b8987518d7c8a7beae51", [:mix], [{:nerves, "~> 0.7", [hex: :nerves, repo: "hexpm", optional: false]}, {:nerves_toolchain_ctng, "~> 1.1", [hex: :nerves_toolchain_ctng, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.1.0", "0f03e4a3f3beef5fe271de0148b9f106c417e57f303f635c21c74b4bd6eb68ee", [:mix], [], "hexpm"}}


### PR DESCRIPTION
Brings in
* Fix deprecation warnings for Elixir 1.5
* fwup 0.15.4 - Changed signing keys to be base64 encoded. Added commandline parameters for passing public and private keys via commandline arguments
* Improved error messaging for when a toolchain is not found when requiring nerves_env.exs