### PR TITLE
Provisioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /nerves/build
   docker:
-    - image: nervesproject/nerves_system_br:1.4.0
+    - image: nervesproject/nerves_system_br:1.4.2
   environment:
     ENV: CI
     MIX_ENV: test

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ function.
 
 Keys used by this system are:
 
-Key             | Example Value     | Description
-:-------------- | :---------------- | :----------
-`serial_number` | "1234578"`        | By default, this string is used to create unique hostnames and Erlang node names. If unset, it defaults to part of the Raspberry Pi's device ID.
+Key                    | Example Value     | Description
+:--------------------- | :---------------- | :----------
+`nerves_serial_number` | "1234578"`        | By default, this string is used to create unique hostnames and Erlang node names. If unset, it defaults to part of the Raspberry Pi's device ID.
 
 The normal procedure would be to set these keys once in manufacturing or before
 deployment and then leave them alone.
@@ -81,15 +81,15 @@ For example, to provision a serial number on a running device, run the following
 and reboot:
 
 ```elixir
-iex> cmd("fw_setenv serial_number 1234")
+iex> cmd("fw_setenv nerves_serial_number 1234")
 ```
 
 This system supports setting the serial number offline. To do this, set the
-`SERIAL_NUMBER` environment variable when burning the firmware. If you're
+`NERVES_SERIAL_NUMBER` environment variable when burning the firmware. If you're
 programming MicroSD cards using `fwup`, the commandline is:
 
 ```sh
-sudo SERIAL_NUMBER=1234 fwup path_to_firmware.fw
+sudo NERVES_SERIAL_NUMBER=1234 fwup path_to_firmware.fw
 ```
 
 Serial numbers are stored on the MicroSD card so if the MicroSD card is
@@ -97,6 +97,12 @@ replaced, the serial number will need to be reprogrammed. The numbers are stored
 in a U-boot environment block. This is a special region that is separate from
 the application partition so reformatting the application partition will not
 lose the serial number or any other data stored in this block.
+
+Additional key value pairs can be provisioned by overriding the default provisioning.conf
+file location by setting the environment variable 
+`NERVES_PROVISIONING=/path/to/provisioning.conf`. The default provisioning.conf
+will set the `nerves_serial_number`, if you override the location to this file,
+you will be responsible for setting this yourself.
 
 ## Linux kernel and RPi firmware/userland
 

--- a/fwup.conf
+++ b/fwup.conf
@@ -23,6 +23,7 @@ define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
 define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p3") # Linux part number is 1-based
 define(NERVES_FW_APPLICATION_PART0_FSTYPE, "ext4")
 define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
+define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.conf")
 
 # Default paths if not specified via the commandline
 define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")
@@ -180,7 +181,14 @@ task complete {
     on-init {
         mbr_write(mbr-a)
 
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
+
         uboot_clearenv(uboot-env)
+
+        include("${NERVES_PROVISIONING}")
+        
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
         uboot_setenv(uboot-env, "nerves_fw_devpath", ${NERVES_FW_DEVPATH})
         uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
@@ -195,17 +203,6 @@ task complete {
         uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
         uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
         uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
-
-        # Support setting device serial numbers when creating MicroSD cards.
-        # Note that the '$' is escaped so that environment variable replacement
-        # happens at "burn" time rather than at firmware creation time. No
-        # serial numbers are stored in the .fw file. If left blank, the device
-        # will default to a built-in ID.
-        uboot_setenv(uboot-env, "serial_number", "\${SERIAL_NUMBER}")
-
-        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
-        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
-        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
     }
 
     on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }

--- a/fwup_include/provisioning.conf
+++ b/fwup_include/provisioning.conf
@@ -1,0 +1,6 @@
+# Support setting device serial numbers when creating MicroSD cards.
+# Note that the '$' is escaped so that environment variable replacement
+# happens at "burn" time rather than at firmware creation time. No
+# serial numbers are stored in the .fw file. If left blank, the device
+# will default to a built-in ID.
+uboot_setenv(uboot-env, "nerves_serial_number", "\${NERVES_SERIAL_NUMBER}")

--- a/mix.exs
+++ b/mix.exs
@@ -72,19 +72,21 @@ defmodule NervesSystemRpi2.MixProject do
 
   defp package_files do
     [
+      "fwup_include",
+      "rootfs_overlay",
+      "CHANGELOG.md",
+      "cmdline.txt",
+      "config.txt",
+      "fwup-revert.conf",
+      "fwup.conf",
       "LICENSE",
+      "linux-4.4.defconfig",
       "mix.exs",
       "nerves_defconfig",
-      "README.md",
-      "VERSION",
-      "rootfs_overlay",
-      "fwup.conf",
-      "fwup-revert.conf",
-      "post-createfs.sh",
       "post-build.sh",
-      "cmdline.txt",
-      "linux-4.4.defconfig",
-      "config.txt"
+      "post-createfs.sh",
+      "README.md",
+      "VERSION"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesSystemRpi2.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_system_br, "1.4.1", runtime: false},
+      {:nerves_system_br, "1.4.2", runtime: false},
       {:nerves_toolchain_arm_unknown_linux_gnueabihf, "1.1.0", runtime: false},
       {:nerves_system_linter, "~> 0.3.0", runtime: false},
       {:ex_doc, "~> 0.18", only: :dev}

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves": {:hex, :nerves, "1.1.0", "acc8af6d508793aa68be3aeefda7be4e01c2bc4cfcb729e335d60212d2cfcf12", [:mix], [{:distillery, "~> 1.4", [hex: :distillery, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
-  "nerves_system_br": {:hex, :nerves_system_br, "1.4.1", "58a85d4dd85c84c7d1b535f9295aae64283638a9d9f49b8279f22ef1673eef42", [:mix], [], "hexpm"},
+  "nerves_system_br": {:hex, :nerves_system_br, "1.4.2", "da1fac7a7a140a77d1effe7f48c038a93fcd5d1513c20ada2fe60e651ddc03f4", [:mix], [], "hexpm"},
   "nerves_system_linter": {:hex, :nerves_system_linter, "0.3.0", "84e0f63c8ac196b16b77608bbe7df66dcf352845c4e4fb394bffd2b572025413", [:mix], [], "hexpm"},
   "nerves_toolchain_arm_unknown_linux_gnueabihf": {:hex, :nerves_toolchain_arm_unknown_linux_gnueabihf, "1.1.0", "ca466a656f8653346a8551a35743f7c41046f3d53e945723e970cb4a7811e617", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}, {:nerves_toolchain_ctng, "~> 1.5.0", [hex: :nerves_toolchain_ctng, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.5.0", "34b8f5664858ff6ce09730b26221441398acd1fa361b8c6d744d9ec18238c16b", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm"},

--- a/post-build.sh
+++ b/post-build.sh
@@ -6,3 +6,6 @@ set -e
 # active firmware.
 mkdir -p $TARGET_DIR/usr/share/fwup
 $HOST_DIR/usr/bin/fwup -c -f $NERVES_DEFCONFIG_DIR/fwup-revert.conf -o $TARGET_DIR/usr/share/fwup/revert.fw
+
+# Copy the fwup includes to the images dir
+cp -rf $NERVES_DEFCONFIG_DIR/fwup_include $BINARIES_DIR

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -55,7 +55,7 @@
 # Assign a hostname of the form "nerves-<serial_number>". The serial number is either
 # read from the U-boot environment block that contains provisioning information from
 # manufactoring or it uses 4 digits of the Raspberry Pi's device ID
--d "/usr/bin/boardid -b uboot_env -u serial_number -b rpi -n 4"
+-d "/usr/bin/boardid -b uboot_env -u nerves_serial_number -b uboot_env -u serial_number -b rpi -n 4"
 -n nerves-%s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the


### PR DESCRIPTION
This PR updates the fwup.conf to include a provisioning.conf file for device provisioning to happen during the execution of the complete task. This PR also changes the serial_number key to nerves_serial_number.